### PR TITLE
fix: separated the errors and warnings, updated doc, tested cli, fixe…

### DIFF
--- a/core/cli/src/types.ts
+++ b/core/cli/src/types.ts
@@ -4,41 +4,6 @@
 export type State = "success" | "warning" | "error";
 
 /**
- * Type representing a validation result containing state, message, input, output (optional), assetName, and validatorId.
- */
-export interface Result {
-  /**
-   * The current validation state.
-   */
-  state: State;
-
-  /**
-   * An optional message or object associated with the validation result. Defaults to `undefined`.
-   */
-  message: string | object | undefined;
-
-  /**
-   * The input data that was validated.
-   */
-  input: unknown;
-
-  /**
-   * The output data resulting from successful validation (optional). Set to `undefined` when there is an error/warning.
-   */
-  output: unknown | undefined;
-
-  /**
-   * The name of the asset being validated.
-   */
-  assetName: string;
-
-  /**
-   * The identifier for the validator used in this result.
-   */
-  validatorId: string;
-}
-
-/**
  * Type representing a record containing data keyed by string.
  */
 export type DataRead = Record<string, unknown>;

--- a/core/validator/__tests__/inputs/test.cetardio.ts
+++ b/core/validator/__tests__/inputs/test.cetardio.ts
@@ -92,6 +92,7 @@ Deno.test("TestCetardio", () => {
           ],
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/inputs/test.cornucopias.ts
+++ b/core/validator/__tests__/inputs/test.cornucopias.ts
@@ -97,6 +97,7 @@ Deno.test("TestCornucopias", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/inputs/test.deadpxlz.ts
+++ b/core/validator/__tests__/inputs/test.deadpxlz.ts
@@ -80,6 +80,7 @@ Deno.test("TestDeadpxlz", () => {
           ],
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/inputs/test.earthnode.ts
+++ b/core/validator/__tests__/inputs/test.earthnode.ts
@@ -87,6 +87,7 @@ Deno.test("TestEarthnode", () => {
           ],
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/inputs/test.kwic.ts
+++ b/core/validator/__tests__/inputs/test.kwic.ts
@@ -108,6 +108,7 @@ Deno.test("TestKwic", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/inputs/test.mogi.ts
+++ b/core/validator/__tests__/inputs/test.mogi.ts
@@ -112,6 +112,7 @@ Deno.test("TestMogi", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/inputs/test.pavia.ts
+++ b/core/validator/__tests__/inputs/test.pavia.ts
@@ -103,6 +103,7 @@ Deno.test("TestPavia", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/test.attributes.ts
+++ b/core/validator/__tests__/test.attributes.ts
@@ -44,6 +44,7 @@ Deno.test("KeyAttributesValidator - withWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });
@@ -68,6 +69,6 @@ Deno.test("KeyAttributesValidator - withSuccess", () => {
   const result = mainValidator.GetResults();
 
   assertEquals(result, {
-    NO_ASSET_NAME_PROVIDED: { status: "success", warnings: [] },
+    NO_ASSET_NAME_PROVIDED: { status: "success", warnings: [], errors: [] },
   });
 });

--- a/core/validator/__tests__/test.case.ts
+++ b/core/validator/__tests__/test.case.ts
@@ -64,6 +64,7 @@ Deno.test("KeyTitleCase - withWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });
@@ -78,7 +79,9 @@ Deno.test("KeyCamelCase - withSuccess", () => {
 
   const result = mainValidator.GetResults();
 
-  assertEquals(result, { asset000: { status: "success", warnings: [] } });
+  assertEquals(result, {
+    asset000: { status: "success", warnings: [], errors: [] },
+  });
 });
 
 Deno.test("KeySnakeCase - withWarning", () => {
@@ -107,6 +110,7 @@ Deno.test("KeySnakeCase - withWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });
@@ -137,6 +141,7 @@ Deno.test("KeyLowerCase - withWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });
@@ -174,6 +179,7 @@ Deno.test("KeyUpperCase - withWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/test.duplicate-image.ts
+++ b/core/validator/__tests__/test.duplicate-image.ts
@@ -45,6 +45,7 @@ Deno.test("DuplicateImage - withWarning", () => {
           message: "Image: adibou.png has been detected as a duplicate.",
         },
       ],
+      errors: [],
     },
   });
 });
@@ -91,6 +92,7 @@ Deno.test("DuplicateImage - withWarning", () => {
             "Image: windows95C:adibou.png has been detected as a duplicate.",
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/test.duplicate-name.ts
+++ b/core/validator/__tests__/test.duplicate-name.ts
@@ -39,7 +39,8 @@ Deno.test("DuplicateName - withWarning", () => {
   assertEquals(result, {
     asset_0002: {
       status: "error",
-      warnings: [
+      warnings: [],
+      errors: [
         {
           validatorId: "duplicate-name",
           message: "Name: asset_0000 has been detected as a duplicate.",

--- a/core/validator/__tests__/test.duplicate.ts
+++ b/core/validator/__tests__/test.duplicate.ts
@@ -80,6 +80,7 @@ Deno.test("DuplicateKeys - withWarnings", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });
@@ -120,5 +121,7 @@ Deno.test("DuplicateKeys - withSuccess", () => {
 
   const result = mainValidator.GetResults();
 
-  assertEquals(result, { asset000: { status: "success", warnings: [] } });
+  assertEquals(result, {
+    asset000: { status: "success", warnings: [], errors: [] },
+  });
 });

--- a/core/validator/__tests__/test.fort-gotten.ts
+++ b/core/validator/__tests__/test.fort-gotten.ts
@@ -52,7 +52,7 @@ Deno.test("fort-gotten.json", () => {
   const result = mainValidator.GetResults();
 
   assertEquals(result, {
-    FortGottenEp02Kid3195: { status: "success", warnings: [] },
+    FortGottenEp02Kid3195: { status: "success", warnings: [], errors: [] },
     FortGottenEp02Kid3963: {
       status: "warning",
       warnings: [
@@ -96,6 +96,7 @@ Deno.test("fort-gotten.json", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/test.similar.ts
+++ b/core/validator/__tests__/test.similar.ts
@@ -39,7 +39,9 @@ Deno.test("CompareRootKeys - withSuccess", () => {
 
   const result = mainValidator.GetResults();
 
-  assertEquals(result, { asset000: { status: "success", warnings: [] } });
+  assertEquals(result, {
+    asset000: { status: "success", warnings: [], errors: [] },
+  });
 });
 
 Deno.test("CompareRootKeys - withWarning", () => {
@@ -91,6 +93,7 @@ Deno.test("CompareRootKeys - withWarning", () => {
           ],
         },
       ],
+      errors: [],
     },
   });
 });
@@ -132,7 +135,9 @@ Deno.test("CompareRootValues - withSuccess", () => {
 
   const result = mainValidator.GetResults();
 
-  assertEquals(result, { asset000: { status: "success", warnings: [] } });
+  assertEquals(result, {
+    asset000: { status: "success", warnings: [], errors: [] },
+  });
 });
 
 Deno.test("CompareAttributesValues - withSuccess", () => {
@@ -188,6 +193,7 @@ Deno.test("CompareAttributesValues - withSuccess", () => {
           ],
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/test.traits.ts
+++ b/core/validator/__tests__/test.traits.ts
@@ -65,6 +65,7 @@ Deno.test("KeyTraitsValidator - withWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/__tests__/test.white-space.ts
+++ b/core/validator/__tests__/test.white-space.ts
@@ -55,6 +55,7 @@ Deno.test("KeyWhiteSpace - withWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });
@@ -99,6 +100,7 @@ Deno.test("KeyWhiteSpace - withArrayAndWarning", () => {
           },
         },
       ],
+      errors: [],
     },
   });
 });

--- a/core/validator/deno.json
+++ b/core/validator/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ada-anvil/metadraft-validator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "exports": "./src/mod.ts",
   "imports": {
     "@deno/dnt": "jsr:@deno/dnt@^0.41.2",

--- a/core/validator/docs/output.md
+++ b/core/validator/docs/output.md
@@ -2,7 +2,13 @@
 
 Currently there is 3 formats:
 
-To get more examples take a look in the `__tests__/` directory.
+The validation process produces output in one of the following formats.
+You can find more examples in the `__tests__/` directory.
+
+Each validator's output is sorted into either the `warnings` or `errors` array within the asset object.
+
+The top-level status is an `error` if any test returns an error.
+Otherwise, it can be a `warning` or `success` using the same logic as the `error`.
 
 **Message only**:
 
@@ -15,11 +21,17 @@ assetNameXYZ: {
       message: "...",
     },
   ],
+  errors: [
+    {
+      validatorId: "...",
+      message: "...",
+    },
+  ],
 }
 ```
 
 **Message as an object for details**:
-*The warnings object structure can change depending on the context of the rule*
+*(the structure may vary depending on the context of the rule)*
 
 ```json
 assetNameXYZ: {
@@ -44,6 +56,7 @@ assetNameXYZ: {
       },
     },
   ],
+  errors: []
 }
 ```
 
@@ -93,5 +106,6 @@ assetNameXYZ: {
       },
     },
   ],
+  errors: []
 }
 ```

--- a/core/validator/src/core.ts
+++ b/core/validator/src/core.ts
@@ -127,13 +127,15 @@ export class Validator implements IMainValidator {
 
       // Build the validations output object.
       if (!this.validations[assetName]) {
-        this.validations[assetName] = { status: "success", warnings: [] };
+        this.validations[assetName] = { status: "success", warnings: [], errors: [] };
       }
       if (validations.status !== "success") {
-        this.validations[assetName].warnings.push(...validations.warnings);
+        this.validations[assetName].status = validations.status;
         if (validations.status === "error") {
-          this.validations[assetName].status = validations.status;
-        } else if (
+          this.validations[assetName].errors.push(...validations.warnings);
+        } else if(validations.status === "warning"){
+          this.validations[assetName].warnings.push(...validations.warnings);
+        }else if (
           this.validations[assetName].status !== "warning" &&
           this.validations[assetName].status !== "error"
         )

--- a/core/validator/src/rules/duplicate-image.ts
+++ b/core/validator/src/rules/duplicate-image.ts
@@ -67,6 +67,7 @@ export class DuplicateImage extends BaseValidator {
             validations[entry.assetName] = {
               status: "warning",
               warnings: [],
+              errors: [],
             };
           }
           validations[entry.assetName].warnings.push({

--- a/core/validator/src/rules/duplicate-name-and-image.ts
+++ b/core/validator/src/rules/duplicate-name-and-image.ts
@@ -88,14 +88,29 @@ export class DuplicateNameAndImage extends BaseValidator {
       if (!errorDetected) {
         success.push(entry.metadata);
       } else {
-        validations[entry.assetName].warnings.push({
-          validatorId: this.id,
-          message: `Name: ${entry.metadata.name} has been detected as a duplicate.`,
-        });
+        if (!validations[entry.assetName]) {
+          validations[entry.assetName] = {
+            status: "warning",
+            warnings: [],
+            errors: [],
+          };
+        }
 
+        const message = `Name: ${entry.metadata.name} has been detected as a duplicate.`;
         if (nameDuplicated) {
           validations[entry.assetName].status = "error";
-        } else if (validations[entry.assetName].status !== "error") {
+          validations[entry.assetName].errors.push({
+            validatorId: this.id,
+            message,
+          });
+        } else {
+          validations[entry.assetName].warnings.push({
+            validatorId: this.id,
+            message,
+          });
+        }
+
+        if (validations[entry.assetName].status !== "error") {
           validations[entry.assetName].status = "warning";
         }
       }

--- a/core/validator/src/rules/duplicate-name.ts
+++ b/core/validator/src/rules/duplicate-name.ts
@@ -64,13 +64,15 @@ export class DuplicateName extends BaseValidator {
             validations[entry.assetName] = {
               status: "error",
               warnings: [],
+              errors: [],
             };
           }
-          validations[entry.assetName].warnings.push({
+
+          validations[entry.assetName].status = "error";
+          validations[entry.assetName].errors.push({
             validatorId: this.id,
             message: `Name: ${entry.metadata.name} has been detected as a duplicate.`,
           });
-          validations[entry.assetName].status = "error";
         }
         seen.names.add(entry.metadata.name);
       }

--- a/core/validator/src/utils/getState.ts
+++ b/core/validator/src/utils/getState.ts
@@ -78,6 +78,8 @@ export function GetValidationOutput(
 
   return {
     status: state,
-    warnings: [{ validatorId: validatorId, message }],
+    warnings:
+      state === "warning" ? [{ validatorId: validatorId, message }] : [],
+    errors: state === "error" ? [{ validatorId: validatorId, message }] : [],
   };
 }

--- a/core/validator/src/utils/types.ts
+++ b/core/validator/src/utils/types.ts
@@ -245,6 +245,10 @@ export type StateOutput = {
     validatorId: string;
     message: string | object | undefined;
   }>;
+  errors: Array<{
+    validatorId: string;
+    message: string | object | undefined;
+  }>;
 };
 
 export type Metadata = {


### PR DESCRIPTION
- as per requested for the frontend structure
- the output is as follow:
```
{
    asset000: { status: "success", warnings: [], errors: [] },
  }
```
- Updated documentation
- ran test, lint and publish dry-run and tested cli